### PR TITLE
Push: Neexistující repositář(adresář na CI) při push zařadí do fronty pokus o vytvoření repositáře

### DIFF
--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -189,6 +189,7 @@ services:
 		arguments:
 			logger: @Kdyby\Monolog\Logger::channel('push')
 			pushProducer: @\Kdyby\RabbitMq\Connection::getProducer('push')
+			createTestServerProducer: @\Kdyby\RabbitMq\Connection::getProducer('createTestServer')
 		setup:
 			- addOnBuildReady(@CI\Builds\PhpCs\PublishPhpCs)
 			- addOnBuildReady(@CI\Builds\Tests\PublishTests)


### PR DESCRIPTION
Pokud přijde hook z GH pro aktualizaci repositáře a repozitář na CIServeru je z nějakého důvodu smazaný, aktualizace skončí failem `MSG_REJECT` (stávající stav), ale zařadí se do fronty `createTestServer` nový pokus o jeho sestavení (přidaná funkcionalita)