### PR TITLE
Push locking

### DIFF
--- a/app/SyncLock/Exception/LockNotFoundException.php
+++ b/app/SyncLock/Exception/LockNotFoundException.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace CI\SyncLock\Exception;
+
+class LockNotFoundException extends \UnexpectedValueException
+{
+
+}

--- a/app/SyncLock/LockPayload.php
+++ b/app/SyncLock/LockPayload.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace CI\SyncLock;
+
+class LockPayload implements \JsonSerializable
+{
+
+	/**
+	 * @var bool
+	 */
+	private $locked;
+
+	/**
+	 * @var int
+	 */
+	private $timestamp;
+
+
+	public function __construct(
+		bool $locked,
+		int $timestamp
+	)
+	{
+		$this->locked = $locked;
+		$this->timestamp = $timestamp;
+	}
+
+
+	public function isLocked(): bool
+	{
+		return $this->locked;
+	}
+
+
+	public function getTimestamp(): int
+	{
+		return $this->timestamp;
+	}
+
+
+	public function jsonSerialize(): array
+	{
+		return [
+			'locked' => $this->isLocked(),
+			'timestamp' => $this->getTimestamp(),
+		];
+	}
+
+
+	public static function createFromStdClass(\stdClass $payload): self
+	{
+		return new self($payload->locked, $payload->timestamp);
+	}
+}

--- a/app/SyncLock/PushLock.php
+++ b/app/SyncLock/PushLock.php
@@ -1,0 +1,169 @@
+<?php declare(strict_types = 1);
+
+namespace CI\SyncLock;
+
+class PushLock
+{
+
+	/**
+	 * @var string
+	 */
+	private $path;
+
+	/**
+	 * @var \DateInterval
+	 */
+	private $lockExpiration;
+
+
+	public function __construct(
+		string $path,
+		\DateInterval $lockExpiration
+	)
+	{
+		$this->path = $path;
+		$this->lockExpiration = $lockExpiration;
+	}
+
+	public function isLocked(): bool
+	{
+		try {
+			$this->getLock();
+		} catch (\CI\SyncLock\Exception\LockNotFoundException $e) {
+			return FALSE;
+		}
+
+		try {
+			$lockPayload = $this->getPayload();
+		} catch (\Nette\Utils\JsonException $e) {
+			return FALSE;
+		}
+
+		if ( ! $lockPayload->isLocked()) {
+			return FALSE;
+		}
+
+		try {
+			return $this->isLockValid();
+		} catch (\Nette\Utils\JsonException $e) {
+			return FALSE;
+		}
+	}
+
+
+	public function checkAndLock(\DateTimeImmutable $now): bool
+	{
+		if ($this->isLocked()) {
+			return FALSE;
+		}
+
+		try {
+			$filePointer = $this->getLock();
+		} catch (\CI\SyncLock\Exception\LockNotFoundException $exception) {
+			$this->createLock($now);
+
+			return TRUE;
+		}
+
+		$writeResult = $this->safeWrite($filePointer, TRUE, $this->getExpireTime($now));
+		\fclose($filePointer);
+
+		return $writeResult;
+	}
+
+
+	public function releaseLock(): bool
+	{
+		try {
+			$filePointer = $this->getLock();
+		} catch (\CI\SyncLock\Exception\LockNotFoundException $e) {
+			return TRUE;
+		}
+
+		$writeResult = $this->safeWrite($filePointer, FALSE, \time());
+		\fclose($filePointer);
+
+		return $writeResult;
+	}
+
+
+	/**
+	 * @throws \CI\SyncLock\Exception\LockNotFoundException
+	 */
+	private function getLock()
+	{
+		if ( ! \is_readable($this->path)) {
+			throw new \CI\SyncLock\Exception\LockNotFoundException();
+		}
+
+		$filePointer = \fopen($this->path, 'r+');
+
+		if ($filePointer === FALSE) {
+			throw new \CI\SyncLock\Exception\LockNotFoundException();
+		}
+
+		return $filePointer;
+	}
+
+
+	/**
+	 * @throws \Nette\Utils\JsonException
+	 */
+	private function createLock(\DateTimeImmutable $now): void
+	{
+		\Nette\Utils\FileSystem::write(
+			$this->path,
+			\Nette\Utils\Json::encode(new LockPayload(TRUE, $this->getExpireTime($now)))
+		);
+	}
+
+
+	/**
+	 * @throws \Nette\Utils\JsonException
+	 */
+	private function isLockValid(): bool
+	{
+		$lockPayload = $this->getPayload();
+		$lockDateTime = \DateTimeImmutable::createFromFormat('U', (string) $lockPayload->getTimestamp());
+		$now = new \DateTimeImmutable();
+
+		return $lockDateTime > $now;
+	}
+
+
+	/**
+	 * @throws \Nette\Utils\JsonException
+	 */
+	private function getPayload(): LockPayload
+	{
+		$payload = \file_get_contents($this->path);
+		$lockPayload = \Nette\Utils\Json::decode($payload);
+
+		return LockPayload::createFromStdClass($lockPayload);
+	}
+
+
+	private function safeWrite($filePointer, bool $locked, int $timestamp): bool
+	{
+		if ( ! \flock($filePointer, \LOCK_EX)) {
+			return FALSE;
+		}
+
+		\ftruncate($filePointer, 0);
+		\fwrite(
+			$filePointer,
+			\Nette\Utils\Json::encode(
+				new LockPayload($locked, $timestamp)
+			)
+		);
+		\flock($filePointer, \LOCK_UN);
+
+		return TRUE;
+	}
+
+
+	private function getExpireTime(\DateTimeImmutable $now): int
+	{
+		return $now->add($this->lockExpiration)->getTimestamp();
+	}
+}

--- a/app/SyncLock/PushLockFactory.php
+++ b/app/SyncLock/PushLockFactory.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace CI\SyncLock;
+
+class PushLockFactory
+{
+	public function create(string $path): PushLock
+	{
+		return new PushLock($path, new \DateInterval("PT5M"));
+	}
+}

--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -356,3 +356,6 @@ services:
 	-
 		class: \League\OAuth2\Client\Provider\Github
 		factory: \CI\GitHub\ProviderFactory(%github.clientId%, %github.clientSecret%, %github.scope%)::create()
+
+	syncLock.pushLockFactory:
+		factory: CI\SyncLock\PushLockFactory

--- a/tests/Unit/SyncLock/PushLockTest.php
+++ b/tests/Unit/SyncLock/PushLockTest.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+namespace CITests\Unit\SyncLock;
+
+include __DIR__ . '/../../bootstrap.php';
+
+/**
+ * @testCase
+ */
+class PushLockTest extends \Tester\TestCase
+{
+
+	private const LOCK_FILE = 'push.lock';
+
+	public function testLockingPush(): void
+	{
+		$lockPush = new \CI\SyncLock\PushLock(
+			self::LOCK_FILE,
+			new \DateInterval("PT5M")
+		);
+
+		\Tester\Assert::true($lockPush->checkAndLock(new \DateTimeImmutable()));
+		\Tester\Assert::true($lockPush->isLocked());
+	}
+
+
+	public function testReleasingLock(): void
+	{
+		$lockPush = new \CI\SyncLock\PushLock(
+			self::LOCK_FILE,
+			new \DateInterval("PT5M")
+		);
+
+		\Tester\Assert::true($lockPush->checkAndLock(new \DateTimeImmutable()));
+		\Tester\Assert::true($lockPush->isLocked());
+		\Tester\Assert::true($lockPush->releaseLock());
+		\Tester\Assert::false($lockPush->isLocked());
+	}
+
+
+	public function testRaceCondition(): void
+	{
+		$lockPush = new \CI\SyncLock\PushLock(
+			self::LOCK_FILE,
+			new \DateInterval("PT5M")
+		);
+
+		$otherProcessLock = new \CI\SyncLock\PushLock(
+			self::LOCK_FILE,
+			new \DateInterval("PT5M")
+		);
+
+		\Tester\Assert::true($lockPush->checkAndLock(new \DateTimeImmutable()));
+		\Tester\Assert::false($otherProcessLock->checkAndLock(new \DateTimeImmutable()));
+	}
+
+
+	public function testLockExpiration(): void
+	{
+		$lockPush = new \CI\SyncLock\PushLock(
+			self::LOCK_FILE,
+			new \DateInterval("PT5M")
+		);
+
+		$sixMinutesAgo = new \DateTimeImmutable("-6 minutes");
+
+		\Tester\Assert::true($lockPush->checkAndLock($sixMinutesAgo));
+		\Tester\Assert::true($lockPush->checkAndLock(new \DateTimeImmutable()));
+	}
+
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		\Nette\Utils\FileSystem::delete(self::LOCK_FILE);
+	}
+
+
+}
+(new PushLockTest())->run();


### PR DESCRIPTION
Implementace zámku pro aktualizaci testovacích serverů, abychom mohli mít v CI vícero consumerů.

Nová logika vytváří soubor v adresáři testovacího serveru a ukládá do něj stav zamčeno/nezamčeno a timestamp. Platnost zámku je 5 min. Po této době zámek vyprší a další pokus o zamčení bude úspěšný.

Samotný zápis do souboru je hlídaný pomocí zámku na souboru, takže by nemělo dojít k současnému zápisu vícero procesů do souboru zároveň.