### PR TITLE
Úprava placeholderů při vytváření testovacího serveru

### DIFF
--- a/app/Builds/CreateTestServer/Consumers/CreateTestServer.php
+++ b/app/Builds/CreateTestServer/Consumers/CreateTestServer.php
@@ -150,14 +150,18 @@ class CreateTestServer implements \Kdyby\RabbitMq\IConsumer
 
 			$defaultLocalNeonPath = $cwd . '/../local.neon';
 			if (is_readable($defaultLocalNeonPath)) {
-				$testName = 'staging';
+				$testName = $databaseName = 'staging';
 				$redisCacheName = 'redis' . $build->pullRequestNumber;
 
-				if ($databaseFiles) {
+				if ($build->pullRequestNumber !== NULL) {
 					$testName = 'test' . $build->pullRequestNumber;
 				}
 
-				$cmd = sprintf('sed "s/testX/%s/; s/redisX/%s/" < %s > %s/app/config/local.neon', $testName, $redisCacheName, $defaultLocalNeonPath, $cwd);
+				if ($databaseFiles) {
+					$databaseName = 'test' . $build->pullRequestNumber;
+				}
+
+				$cmd = sprintf('sed "s/testX/%s/; s/redisX/%s/; s/testDatabaseX/%s/" < %s > %s/app/config/local.neon', $testName, $redisCacheName, $databaseName, $defaultLocalNeonPath, $cwd);
 				$this->processRunner->runProcess($this->logger, $cwd, $cmd, $loggingContext);
 			}
 


### PR DESCRIPTION
`testX` obsahuje název testu (staging / test123)
`testDatabaseX` pokud PR obsahuje migrace, tak se vygeneruje název databáze (původně jako `testX`) ⚠️ BC break
`redisX` původní chování